### PR TITLE
feat: Implement 1P/2P selection logic

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -88,12 +88,14 @@ public final class Core {
 		int height = frame.getHeight();
 
 		levelManager = new LevelManager();
-		GameState gameState = new GameState(1, 0, MAX_LIVES, MAX_LIVES, 0, 0,0);
+		GameState gameState = new GameState(1, 0, MAX_LIVES, MAX_LIVES, 0, 0,0, 1);
 
 
         int returnCode = 1;
 		do {
-            gameState = new GameState(1, 0, MAX_LIVES,MAX_LIVES, 0, 0,gameState.getCoin());
+			int currentCoins = gameState.getCoin();
+			int playerCount = TitleScreen.getSelectPlayerCount();
+            gameState = new GameState(1, 0, MAX_LIVES,MAX_LIVES, 0, 0,currentCoins, playerCount );
 			switch (returnCode) {
                 case 1:
                     // Main menu.
@@ -107,7 +109,7 @@ public final class Core {
                     break;
                 case 2:
                     do {
-                        // One extra life every few levels
+                        // One extra life every few levelsa
                         boolean bonusLife = gameState.getLevel()
                                 % EXTRA_LIFE_FRECUENCY == 0
                                 && gameState.getLivesRemaining() < MAX_LIVES;
@@ -164,7 +166,8 @@ public final class Core {
 									gameState.getLivesRemainingP2(),   // Keep remaining livesP2
                                     gameState.getBulletsShot(),        // Keep bullets fired
                                     gameState.getShipsDestroyed(),     // Keep ships destroyed
-                                    gameState.getCoin()                // Keep current coins
+                                    gameState.getCoin(),               // Keep current coins
+									playerCount						   // Keep plyaer Count
                             );
                         }
                         // Loop while player still has lives and levels remaining

--- a/src/engine/GameState.java
+++ b/src/engine/GameState.java
@@ -21,6 +21,8 @@ public class GameState {
 	private int shipsDestroyed;
     /** Current coin. */
     private int coin;
+	/** PlayerCount */
+	private int playerCount;
 
 
 	/**
@@ -43,7 +45,7 @@ public class GameState {
 	 */
 	public GameState(final int level, final int score,
 			final int livesRemaining,final int livesRemainingP2, final int bulletsShot,
-			final int shipsDestroyed, final int coin) {
+			final int shipsDestroyed, final int coin, final int playerCount) {
 		this.level = level;
 		this.score = score;
 		this.livesRemaining = livesRemaining;
@@ -51,6 +53,7 @@ public class GameState {
 		this.bulletsShot = bulletsShot;
         this.shipsDestroyed = shipsDestroyed;
         this.coin = coin;
+		this.playerCount = playerCount;
 		    }
 	/**
 	 * @return the level
@@ -90,6 +93,11 @@ public class GameState {
 	public final int getShipsDestroyed() {
 		return shipsDestroyed;
 	}
+
+	/**
+	 * @return the PlayerCount
+	 */
+	public final int getPlayerCount() {return this.playerCount;}
 
     public final int getCoin() { return coin; }
 

--- a/src/engine/GameState.java
+++ b/src/engine/GameState.java
@@ -21,7 +21,7 @@ public class GameState {
 	private int shipsDestroyed;
     /** Current coin. */
     private int coin;
-	/** PlayerCount */
+	/** Number of players in the game (1 or 2).*/
 	private int playerCount;
 
 
@@ -54,7 +54,7 @@ public class GameState {
         this.shipsDestroyed = shipsDestroyed;
         this.coin = coin;
 		this.playerCount = playerCount;
-		    }
+	}
 	/**
 	 * @return the level
 	 */
@@ -95,7 +95,7 @@ public class GameState {
 	}
 
 	/**
-	 * @return the PlayerCount
+	 * @return the number of players.
 	 */
 	public final int getPlayerCount() {return this.playerCount;}
 

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -66,6 +66,8 @@ public class GameScreen extends Screen {
 	private Ship ship;
 	/** Second Player's ship. */
 	private Ship shipP2;
+	/** Selected Player 1p or 2p */
+	private int playerCount;
 	/** Bonus enemy ship that appears sometimes. */
 	private EnemyShip enemyShipSpecial;
 	/** Minimum time between bonus ship appearances. */
@@ -174,10 +176,11 @@ public class GameScreen extends Screen {
 		        this.gameState = gameState;
 				if (this.bonusLife) {
 					this.livesP1++;
-					this.livesP2++;
+					if (this.playerCount == 2) this.livesP2++;
 				}
 		this.bulletsShot = gameState.getBulletsShot();
 		this.shipsDestroyed = gameState.getShipsDestroyed();
+		this.playerCount = gameState.getPlayerCount();
 	}
 
 	/**
@@ -190,11 +193,19 @@ public class GameScreen extends Screen {
         enemyShipFormation = new EnemyShipFormation(this.currentLevel);
 		enemyShipFormation.attach(this);
         this.enemyShipFormation.applyEnemyColorByLevel(this.currentLevel);
-		this.ship = new Ship(this.width / 2 - 100, ITEMS_SEPARATION_LINE_HEIGHT - 20,Color.green);
+		this.ship = new Ship(this.width / 2, ITEMS_SEPARATION_LINE_HEIGHT - 20,Color.green);
 		    this.ship.setPlayerId(1);   //=== [ADD] Player 1 ===
 
-        this.shipP2 = new Ship(this.width / 2 + 100, ITEMS_SEPARATION_LINE_HEIGHT - 20,Color.pink);
-        this.shipP2.setPlayerId(2); // === [ADD] Player2 ===
+		// check player mode
+		if (this.playerCount == 2){
+			this.ship.setPositionX(this.width / 2  - 100);
+			// === [ADD] Player2 ===
+			this.shipP2 = new Ship(this.width / 2 + 100, ITEMS_SEPARATION_LINE_HEIGHT - 20,Color.pink);
+			this.shipP2.setPlayerId(2);
+		}
+		else {
+			this.shipP2 = null;
+		}
         // special enemy initial
 		enemyShipSpecialFormation = new EnemyShipSpecialFormation(this.currentLevel,
 				Core.getVariableCooldown(BONUS_SHIP_INTERVAL, BONUS_SHIP_VARIANCE),
@@ -273,7 +284,7 @@ public class GameScreen extends Screen {
 				}
 			}
 
-			if (this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()) {
+			if (this.playerCount == 2 && this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()) {
 				boolean p2Right = inputManager.isP2KeyDown(java.awt.event.KeyEvent.VK_RIGHT);
 				boolean p2Left  = inputManager.isP2KeyDown(java.awt.event.KeyEvent.VK_LEFT);
 				boolean p2Up    = inputManager.isP2KeyDown(java.awt.event.KeyEvent.VK_UP);
@@ -339,7 +350,7 @@ public class GameScreen extends Screen {
 					break;
 			}
 			this.ship.update();
-			if (this.shipP2 != null) {
+			if (this.playerCount == 2 && this.shipP2 != null) {
 				this.shipP2.update();
 			}
 			// special enemy update
@@ -364,7 +375,7 @@ public class GameScreen extends Screen {
 				this.gameTimer.stop();
 			}
 
-			if ((this.livesP1 > 0) || (this.shipP2 != null && this.livesP2 > 0)) {
+			if ((this.livesP1 > 0) || (this.playerCount == 2 && this.shipP2 != null && this.livesP2 > 0)) {
 				if (this.level == 1) {
 					AchievementManager.getInstance().unlockAchievement("Beginner");
 				} else if (this.level == 3) {
@@ -373,7 +384,7 @@ public class GameScreen extends Screen {
 			}
 		}
 		if (this.levelFinished && this.screenFinishedCooldown.checkFinished()) {
-			if (this.livesP1 > 0 || (this.shipP2 != null && this.livesP2 > 0)) { // Check for win condition
+			if (this.livesP1 > 0 || (this.playerCount == 2 && this.shipP2 != null && this.livesP2 > 0)) { // Check for win condition
 				if (this.currentlevel.getCompletionBonus() != null) {
 					this.coin += this.currentlevel.getCompletionBonus().getCurrency();
 					this.logger.info("Awarded " + this.currentlevel.getCompletionBonus().getCurrency() + " coins for level completion.");
@@ -401,7 +412,7 @@ public class GameScreen extends Screen {
 					this.ship.getPositionY());
 		}
 
-		if (this.shipP2 != null && this.livesP2 > 0) {
+		if (this.playerCount == 2 && this.shipP2 != null && this.livesP2 > 0) {
 			drawManager.drawEntity(this.shipP2, this.shipP2.getPositionX(), this.shipP2.getPositionY());
 		}
 
@@ -435,7 +446,7 @@ public class GameScreen extends Screen {
         drawManager.drawScoreP2(this, this.scoreP2); // Added second line for P2
         drawManager.drawCoin(this,this.coin);
 		drawManager.drawLives(this, this.livesP1);
-		drawManager.drawLivesP2(this, this.livesP2);
+		if(playerCount == 2)  drawManager.drawLivesP2(this, this.livesP2);
 		drawManager.drawTime(this, this.elapsedTime);
 		drawManager.drawItemsHUD(this);
 		drawManager.drawLevel(this, this.currentLevel.getLevelName());
@@ -521,7 +532,7 @@ public class GameScreen extends Screen {
 									+ " lives remaining.");
 						}
 					}
-				} else if (this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()
+				} else if (this.playerCount == 2 && this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()
 						&& checkCollision(bullet, this.shipP2) && !this.levelFinished) {
 					recyclable.add(bullet);
 					if (!this.shipP2.isInvincible()) {
@@ -687,7 +698,7 @@ public class GameScreen extends Screen {
         }
 
         // ===== P2 collision check =====
-        if (!this.levelFinished && this.shipP2 != null && this.livesP2 > 0
+        if (!this.levelFinished && this.playerCount == 2 && this.shipP2 != null && this.livesP2 > 0
                 && !this.shipP2.isDestroyed() && !this.shipP2.isInvincible()) {
             // Check collision with normal enemy ships
             for (EnemyShip enemyShip : this.enemyShipFormation) {
@@ -748,7 +759,7 @@ public class GameScreen extends Screen {
         Set<DropItem> acquiredDropItems = new HashSet<DropItem>();
 
 		if (!this.levelFinished && ((this.livesP1 > 0 && !this.ship.isDestroyed())
-				|| (this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()))) {
+				|| (this.playerCount == 2 && this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()))) {
 			for (DropItem dropItem : this.dropItems) {
 
 				if (this.livesP1 > 0 && !this.ship.isDestroyed() && checkCollision(this.ship, dropItem)) {
@@ -784,7 +795,7 @@ public class GameScreen extends Screen {
 							break;
 					}
 					acquiredDropItems.add(dropItem);
-				} else if (this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()
+				} else if (this.playerCount == 2 && this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()
 						&& checkCollision(this.shipP2, dropItem)) {
 					this.logger.info("Player acquired dropItem: " + dropItem.getItemType());
 
@@ -886,7 +897,7 @@ public class GameScreen extends Screen {
 	            AchievementManager.getInstance().unlockAchievement("Mr. Greedy");
 	        }
 	        return new GameState(this.level, this.score, this.livesP1,this.livesP2,
-	                this.bulletsShot, this.shipsDestroyed,this.coin);
+	                this.bulletsShot, this.shipsDestroyed,this.coin, this.playerCount);
 	    }
 	/**
 	 * Adds one life to the player.
@@ -967,7 +978,8 @@ public class GameScreen extends Screen {
 					}
 					bulletsToRemove.add(b);
 				}
-				else if (this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed() && this.checkCollision(b, this.shipP2)) {
+				else if (this.playerCount == 2 && this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()
+						&& this.checkCollision(b, this.shipP2)) {
 					if (!this.shipP2.isDestroyed()) {
 						this.shipP2.destroy();
 						this.livesP2--;

--- a/src/screen/TitleScreen.java
+++ b/src/screen/TitleScreen.java
@@ -1,386 +1,393 @@
-package screen;
+	package screen;
 
-import java.awt.event.KeyEvent;
-import java.awt.Color;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Random;
+	import java.awt.event.KeyEvent;
+	import java.awt.Color;
+	import java.util.List;
+	import java.util.ArrayList;
+	import java.util.Random;
 
-import engine.Cooldown;
-import engine.Core;
-import engine.DrawManager;
-import engine.DrawManager.SpriteType;
-import entity.Entity;
-import entity.SoundButton;
+	import engine.Cooldown;
+	import engine.Core;
+	import engine.DrawManager;
+	import engine.DrawManager.SpriteType;
+	import entity.Entity;
+	import entity.SoundButton;
 
-import audio.SoundManager;
-
-
-/**
- * Implements the title screen.
- * 
- * @author <a href="mailto:RobertoIA1987@gmail.com">Roberto Izquierdo Amo</a>
- * 
- */
-public class TitleScreen extends Screen {
-
-	/**
-	 * A simple class to represent a star for the animated background.
-	 * Stores the non-rotating base coordinates and speed.
-	 */
-	public static class Star {
-		public float baseX;
-		public float baseY;
-		public float speed;
-		public float brightness;
-        public float brightnessOffset;
-
-		public Star(float baseX, float baseY, float speed) {
-			this.baseX = baseX;
-			this.baseY = baseY;
-			this.speed = speed;
-			this.brightness = 0;
-			this.brightnessOffset = (float) (Math.random() * Math.PI * 2);
-		}
-	}
-
-	/**
-	 * A simple class to represent a shooting star.
-	 */
-	public static class ShootingStar {
-		public float x;
-		public float y;
-		public float speedX;
-		public float speedY;
-
-		public ShootingStar(float x, float y, float speedX, float speedY) {
-			this.x = x;
-			this.y = y;
-			this.speedX = speedX;
-			this.speedY = speedY;
-		}
-	}
-
-	/**
-	 * A simple class to represent a background enemy.
-	 */
-	private static class BackgroundEnemy extends Entity {
-		private int speed;
-
-		public BackgroundEnemy(int positionX, int positionY, int speed, SpriteType spriteType) {
-			super(positionX, positionY, 12 * 2, 8 * 2, Color.WHITE);
-			this.speed = speed;
-			this.spriteType = spriteType;
-		}
-
-		public int getSpeed() {
-			return speed;
-		}
-	}
-
-	/** Milliseconds between changes in user selection. */
-	private static final int SELECTION_TIME = 200;
-	/** Number of stars in the background. */
-	private static final int NUM_STARS = 150;
-	/** Speed of the rotation animation. */
-    private static final float ROTATION_SPEED = 4.0f;
-	/** Milliseconds between enemy spawns. */
-	private static final int ENEMY_SPAWN_COOLDOWN = 2000;
-	/** Probability of an enemy spawning. */
-	private static final double ENEMY_SPAWN_CHANCE = 0.3;
-	/** Milliseconds between shooting star spawns. */
-    private static final int SHOOTING_STAR_COOLDOWN = 3000;
-    /** Probability of a shooting star spawning. */
-    private static final double SHOOTING_STAR_SPAWN_CHANCE = 0.2;
-
-	/** Time between changes in user selection. */
-	private Cooldown selectionCooldown;
-	/** Cooldown for enemy spawning. */
-	private Cooldown enemySpawnCooldown;
-	/** Cooldown for shooting star spawning. */
-    private Cooldown shootingStarCooldown;
-
-	/** List of stars for the background animation. */
-	private List<Star> stars;
-	/** List of background enemies. */
-	private List<Entity> backgroundEnemies;
-	/** List of shooting stars. */
-    private List<ShootingStar> shootingStars;
-
-	/** Sound button on/off object. */
-	private SoundButton soundButton;
-
-    private boolean musicStarted = false;
-
-	/** Current rotation angle of the starfield. */
-    private float currentAngle;
-    /** Target rotation angle of the starfield. */
-    private float targetAngle;
-
-	/** Random number generator. */
-    private Random random;
-
-	/**
-	 * Constructor, establishes the properties of the screen.
-	 * 
-	 * @param width
-	 *            Screen width.
-	 * @param height
-	 *            Screen height.
-	 * @param fps
-	 *            Frames per second, frame rate at which the game is run.
-	 */
-	public TitleScreen(final int width, final int height, final int fps) {
-		super(width, height, fps);
-
-		// Defaults to play.
-		this.returnCode = 2;
-		this.soundButton = new SoundButton(0, 0);
-		this.selectionCooldown = Core.getCooldown(SELECTION_TIME);
-		this.enemySpawnCooldown = Core.getCooldown(ENEMY_SPAWN_COOLDOWN);
-		this.shootingStarCooldown = Core.getCooldown(SHOOTING_STAR_COOLDOWN);
-		this.selectionCooldown.reset();
-		this.enemySpawnCooldown.reset();
-		this.shootingStarCooldown.reset();
-
-		this.random = new Random();
-		this.stars = new ArrayList<Star>();
-		for (int i = 0; i < NUM_STARS; i++) {
-			float speed = (float) (Math.random() * 2.5 + 0.5);
-			this.stars.add(new Star((float) (Math.random() * width),
-					(float) (Math.random() * height), speed));
-		}
-
-		this.backgroundEnemies = new ArrayList<Entity>();
-		this.shootingStars = new ArrayList<ShootingStar>();
-
-		// Initialize rotation angles
-		this.currentAngle = 0;
-		this.targetAngle = 0;
-	}
+	import audio.SoundManager;
 
 
 	/**
-	 * Starts the action.
-	 * 
-	 * @return Next screen code.
+	 * Implements the title screen.
+	 *
+	 * @author <a href="mailto:RobertoIA1987@gmail.com">Roberto Izquierdo Amo</a>
+	 *
 	 */
-	public final int run() {
-		super.run();
+	public class TitleScreen extends Screen {
 
-		return this.returnCode;
-	}
+		/**
+		 * A simple class to represent a star for the animated background.
+		 * Stores the non-rotating base coordinates and speed.
+		 */
+		public static class Star {
+			public float baseX;
+			public float baseY;
+			public float speed;
+			public float brightness;
+			public float brightnessOffset;
 
-	/**
-	 * Updates the elements on screen and checks for events.
-	 */
-	protected final void update() {
-		super.update();
-
-		// Smoothly animate the rotation angle
-        if (currentAngle < targetAngle) {
-            currentAngle = Math.min(currentAngle + ROTATION_SPEED, targetAngle);
-        } else if (currentAngle > targetAngle) {
-            currentAngle = Math.max(currentAngle - ROTATION_SPEED, targetAngle);
-        }
-
-		// Animate stars in their non-rotating space
-		for (Star star : this.stars) {
-			star.baseY += star.speed;
-			if (star.baseY > this.getHeight()) {
-				star.baseY = 0;
-				star.baseX = (float) (Math.random() * this.getWidth());
+			public Star(float baseX, float baseY, float speed) {
+				this.baseX = baseX;
+				this.baseY = baseY;
+				this.speed = speed;
+				this.brightness = 0;
+				this.brightnessOffset = (float) (Math.random() * Math.PI * 2);
 			}
-			// Update brightness for twinkling effect
-			star.brightness = 0.5f + (float) (Math.sin(star.brightnessOffset + System.currentTimeMillis() / 500.0) + 1.0) / 4.0f;
 		}
 
-		// Spawn and move background enemies
-		if (this.enemySpawnCooldown.checkFinished()) {
+		/**
+		 * A simple class to represent a shooting star.
+		 */
+		public static class ShootingStar {
+			public float x;
+			public float y;
+			public float speedX;
+			public float speedY;
+
+			public ShootingStar(float x, float y, float speedX, float speedY) {
+				this.x = x;
+				this.y = y;
+				this.speedX = speedX;
+				this.speedY = speedY;
+			}
+		}
+
+		/**
+		 * A simple class to represent a background enemy.
+		 */
+		private static class BackgroundEnemy extends Entity {
+			private int speed;
+
+			public BackgroundEnemy(int positionX, int positionY, int speed, SpriteType spriteType) {
+				super(positionX, positionY, 12 * 2, 8 * 2, Color.WHITE);
+				this.speed = speed;
+				this.spriteType = spriteType;
+			}
+
+			public int getSpeed() {
+				return speed;
+			}
+		}
+
+		/** Milliseconds between changes in user selection. */
+		private static final int SELECTION_TIME = 200;
+		/** Number of stars in the background. */
+		private static final int NUM_STARS = 150;
+		/** Speed of the rotation animation. */
+		private static final float ROTATION_SPEED = 4.0f;
+		/** Milliseconds between enemy spawns. */
+		private static final int ENEMY_SPAWN_COOLDOWN = 2000;
+		/** Probability of an enemy spawning. */
+		private static final double ENEMY_SPAWN_CHANCE = 0.3;
+		/** Milliseconds between shooting star spawns. */
+		private static final int SHOOTING_STAR_COOLDOWN = 3000;
+		/** Probability of a shooting star spawning. */
+		private static final double SHOOTING_STAR_SPAWN_CHANCE = 0.2;
+
+		/** Time between changes in user selection. */
+		private Cooldown selectionCooldown;
+		/** Cooldown for enemy spawning. */
+		private Cooldown enemySpawnCooldown;
+		/** Cooldown for shooting star spawning. */
+		private Cooldown shootingStarCooldown;
+
+		/** List of stars for the background animation. */
+		private List<Star> stars;
+		/** List of background enemies. */
+		private List<Entity> backgroundEnemies;
+		/** List of shooting stars. */
+		private List<ShootingStar> shootingStars;
+
+		/** Sound button on/off object. */
+		private SoundButton soundButton;
+
+		private boolean musicStarted = false;
+
+		/** Current rotation angle of the starfield. */
+		private float currentAngle;
+		/** Target rotation angle of the starfield. */
+		private float targetAngle;
+
+		/** Random number generator. */
+		private Random random;
+
+		/**
+		 * Constructor, establishes the properties of the screen.
+		 *
+		 * @param width
+		 *            Screen width.
+		 * @param height
+		 *            Screen height.
+		 * @param fps
+		 *            Frames per second, frame rate at which the game is run.
+		 */
+		public TitleScreen(final int width, final int height, final int fps) {
+			super(width, height, fps);
+
+			// Defaults to play.
+			this.returnCode = 2;
+			this.soundButton = new SoundButton(0, 0);
+			this.selectionCooldown = Core.getCooldown(SELECTION_TIME);
+			this.enemySpawnCooldown = Core.getCooldown(ENEMY_SPAWN_COOLDOWN);
+			this.shootingStarCooldown = Core.getCooldown(SHOOTING_STAR_COOLDOWN);
+			this.selectionCooldown.reset();
 			this.enemySpawnCooldown.reset();
-			if (Math.random() < ENEMY_SPAWN_CHANCE) {
-				SpriteType[] enemyTypes = { SpriteType.EnemyShipA1, SpriteType.EnemyShipB1, SpriteType.EnemyShipC1 };
-				SpriteType randomEnemyType = enemyTypes[random.nextInt(enemyTypes.length)];
-				int randomX = (int) (Math.random() * this.getWidth());
-				int speed = random.nextInt(2) + 1;
-				this.backgroundEnemies.add(new BackgroundEnemy(randomX, -20, speed, randomEnemyType));
+			this.shootingStarCooldown.reset();
+
+			this.random = new Random();
+			this.stars = new ArrayList<Star>();
+			for (int i = 0; i < NUM_STARS; i++) {
+				float speed = (float) (Math.random() * 2.5 + 0.5);
+				this.stars.add(new Star((float) (Math.random() * width),
+						(float) (Math.random() * height), speed));
 			}
+
+			this.backgroundEnemies = new ArrayList<Entity>();
+			this.shootingStars = new ArrayList<ShootingStar>();
+
+			// Initialize rotation angles
+			this.currentAngle = 0;
+			this.targetAngle = 0;
 		}
 
-		java.util.Iterator<Entity> enemyIterator = this.backgroundEnemies.iterator();
-		while (enemyIterator.hasNext()) {
-			BackgroundEnemy enemy = (BackgroundEnemy) enemyIterator.next();
-			enemy.setPositionY(enemy.getPositionY() + enemy.getSpeed());
-			if (enemy.getPositionY() > this.getHeight()) {
-				enemyIterator.remove();
-			}
+
+		/**
+		 * Starts the action.
+		 *
+		 * @return Next screen code.
+		 */
+		public final int run() {
+			super.run();
+
+			return this.returnCode;
 		}
 
-		// Spawn and move shooting stars
-        if (this.shootingStarCooldown.checkFinished()) {
-            this.shootingStarCooldown.reset();
-            if (Math.random() < SHOOTING_STAR_SPAWN_CHANCE) {
-                float speedX = (float) (Math.random() * 10 + 5) * (Math.random() > 0.5 ? 1 : -1);
-                float speedY = (float) (Math.random() * 10 + 5) * (Math.random() > 0.5 ? 1 : -1);
-                this.shootingStars.add(new ShootingStar(random.nextInt(this.getWidth()), -10, speedX, speedY));
-            }
-        }
+		/**
+		 * Updates the elements on screen and checks for events.
+		 */
+		protected final void update() {
+			super.update();
 
-		java.util.Iterator<ShootingStar> shootingStarIterator = this.shootingStars.iterator();
-        while (shootingStarIterator.hasNext()) {
-            ShootingStar shootingStar = shootingStarIterator.next();
-            shootingStar.x += shootingStar.speedX;
-            shootingStar.y += shootingStar.speedY;
-            if (shootingStar.x < -20 || shootingStar.x > this.getWidth() + 20 ||
-                shootingStar.y < -20 || shootingStar.y > this.getHeight() + 20) {
-                shootingStarIterator.remove();
-            }
-        }
-
-		// Handle sound button color
-		if (this.returnCode == 5) {
-            float pulse = (float) ((Math.sin(System.currentTimeMillis() / 200.0) + 1.0) / 2.0);
-            Color pulseColor = new Color(0, 0.5f + pulse * 0.5f, 0);
-            this.soundButton.setColor(pulseColor);
-        } else {
-            this.soundButton.setColor(Color.WHITE);
-        }
-
-		draw();
-		if (this.selectionCooldown.checkFinished()
-				&& this.inputDelay.checkFinished()) {
-			if (inputManager.isKeyDown(KeyEvent.VK_UP)
-					|| inputManager.isKeyDown(KeyEvent.VK_W)) {
-				previousMenuItem();
-				this.selectionCooldown.reset();
+			// Smoothly animate the rotation angle
+			if (currentAngle < targetAngle) {
+				currentAngle = Math.min(currentAngle + ROTATION_SPEED, targetAngle);
+			} else if (currentAngle > targetAngle) {
+				currentAngle = Math.max(currentAngle - ROTATION_SPEED, targetAngle);
 			}
-			if (inputManager.isKeyDown(KeyEvent.VK_DOWN)
-					|| inputManager.isKeyDown(KeyEvent.VK_S)) {
-				nextMenuItem();
-				this.selectionCooldown.reset();
+
+			// Animate stars in their non-rotating space
+			for (Star star : this.stars) {
+				star.baseY += star.speed;
+				if (star.baseY > this.getHeight()) {
+					star.baseY = 0;
+					star.baseX = (float) (Math.random() * this.getWidth());
+				}
+				// Update brightness for twinkling effect
+				star.brightness = 0.5f + (float) (Math.sin(star.brightnessOffset + System.currentTimeMillis() / 500.0) + 1.0) / 4.0f;
 			}
-			if (inputManager.isKeyDown(KeyEvent.VK_SPACE)){
-				if (this.returnCode != 5) {
-					this.isRunning = false;
-				} else {
-					this.soundButton.changeSoundState();
 
-					if (SoundButton.getIsSoundOn()) {
-						SoundManager.uncutAllSound();
-					} else {
-						SoundManager.cutAllSound();
-					}
-
-					if (this.soundButton.isTeamCreditScreenPossible()) {
-						this.returnCode = 8;
-						this.isRunning = false;
-					} else {
-						this.selectionCooldown.reset();
-					}
+			// Spawn and move background enemies
+			if (this.enemySpawnCooldown.checkFinished()) {
+				this.enemySpawnCooldown.reset();
+				if (Math.random() < ENEMY_SPAWN_CHANCE) {
+					SpriteType[] enemyTypes = { SpriteType.EnemyShipA1, SpriteType.EnemyShipB1, SpriteType.EnemyShipC1 };
+					SpriteType randomEnemyType = enemyTypes[random.nextInt(enemyTypes.length)];
+					int randomX = (int) (Math.random() * this.getWidth());
+					int speed = random.nextInt(2) + 1;
+					this.backgroundEnemies.add(new BackgroundEnemy(randomX, -20, speed, randomEnemyType));
 				}
 			}
-			if (inputManager.isKeyDown(KeyEvent.VK_RIGHT)
-					|| inputManager.isKeyDown(KeyEvent.VK_D)) {
-				this.returnCode = 5;
-				this.targetAngle += 90;
-				this.selectionCooldown.reset();
+
+			java.util.Iterator<Entity> enemyIterator = this.backgroundEnemies.iterator();
+			while (enemyIterator.hasNext()) {
+				BackgroundEnemy enemy = (BackgroundEnemy) enemyIterator.next();
+				enemy.setPositionY(enemy.getPositionY() + enemy.getSpeed());
+				if (enemy.getPositionY() > this.getHeight()) {
+					enemyIterator.remove();
+				}
 			}
-			if (this.returnCode == 5 && inputManager.isKeyDown(KeyEvent.VK_LEFT)
-					|| inputManager.isKeyDown(KeyEvent.VK_A)) {
+
+			// Spawn and move shooting stars
+			if (this.shootingStarCooldown.checkFinished()) {
+				this.shootingStarCooldown.reset();
+				if (Math.random() < SHOOTING_STAR_SPAWN_CHANCE) {
+					float speedX = (float) (Math.random() * 10 + 5) * (Math.random() > 0.5 ? 1 : -1);
+					float speedY = (float) (Math.random() * 10 + 5) * (Math.random() > 0.5 ? 1 : -1);
+					this.shootingStars.add(new ShootingStar(random.nextInt(this.getWidth()), -10, speedX, speedY));
+				}
+			}
+
+			java.util.Iterator<ShootingStar> shootingStarIterator = this.shootingStars.iterator();
+			while (shootingStarIterator.hasNext()) {
+				ShootingStar shootingStar = shootingStarIterator.next();
+				shootingStar.x += shootingStar.speedX;
+				shootingStar.y += shootingStar.speedY;
+				if (shootingStar.x < -20 || shootingStar.x > this.getWidth() + 20 ||
+					shootingStar.y < -20 || shootingStar.y > this.getHeight() + 20) {
+					shootingStarIterator.remove();
+				}
+			}
+
+			// Handle sound button color
+			if (this.returnCode == 5) {
+				float pulse = (float) ((Math.sin(System.currentTimeMillis() / 200.0) + 1.0) / 2.0);
+				Color pulseColor = new Color(0, 0.5f + pulse * 0.5f, 0);
+				this.soundButton.setColor(pulseColor);
+			} else {
+				this.soundButton.setColor(Color.WHITE);
+			}
+
+			draw();
+			if (this.selectionCooldown.checkFinished()
+					&& this.inputDelay.checkFinished()) {
+				if (inputManager.isKeyDown(KeyEvent.VK_UP)
+						|| inputManager.isKeyDown(KeyEvent.VK_W)) {
+					previousMenuItem();
+					this.selectionCooldown.reset();
+				}
+				if (inputManager.isKeyDown(KeyEvent.VK_DOWN)
+						|| inputManager.isKeyDown(KeyEvent.VK_S)) {
+					nextMenuItem();
+					this.selectionCooldown.reset();
+				}
+				if (inputManager.isKeyDown(KeyEvent.VK_SPACE)){
+					if (this.returnCode != 5) {
+						this.isRunning = false;
+					} else {
+						this.soundButton.changeSoundState();
+
+						if (SoundButton.getIsSoundOn()) {
+							SoundManager.uncutAllSound();
+						} else {
+							SoundManager.cutAllSound();
+						}
+
+						if (this.soundButton.isTeamCreditScreenPossible()) {
+							this.returnCode = 8;
+							this.isRunning = false;
+						} else {
+							this.selectionCooldown.reset();
+						}
+					}
+				}
+				if (inputManager.isKeyDown(KeyEvent.VK_RIGHT)
+						|| inputManager.isKeyDown(KeyEvent.VK_D)) {
+					this.returnCode = 5;
+					this.targetAngle += 90;
+					this.selectionCooldown.reset();
+				}
+				if (this.returnCode == 5 && inputManager.isKeyDown(KeyEvent.VK_LEFT)
+						|| inputManager.isKeyDown(KeyEvent.VK_A)) {
+					this.returnCode = 4;
+					this.targetAngle -= 90;
+					this.selectionCooldown.reset();
+				}
+			}
+		}
+
+		/**
+		 * Shifts the focus to the next menu item.
+		 */
+		private void nextMenuItem() {
+			SoundManager.play("sfx/menu_select.wav");
+			if (this.returnCode == 2)
+				this.returnCode = 3;
+			else if (this.returnCode == 3)
+				this.returnCode = 6;
+			else if (this.returnCode == 6)
 				this.returnCode = 4;
-				this.targetAngle -= 90;
-				this.selectionCooldown.reset();
+			else if (this.returnCode == 4)
+				this.returnCode = 0;
+			else if (this.returnCode == 0)
+				this.returnCode = 2;
+			else if (this.returnCode == 5) {
+				this.returnCode = 0;
 			}
-		}
-	}
-
-	/**
-	 * Shifts the focus to the next menu item.
-	 */
-	private void nextMenuItem() {
-		SoundManager.play("sfx/menu_select.wav");
-		if (this.returnCode == 2)
-			this.returnCode = 3;
-		else if (this.returnCode == 3)
-			this.returnCode = 6;
-		else if (this.returnCode == 6)
-			this.returnCode = 4;
-		else if (this.returnCode == 4)
-			this.returnCode = 0;
-		else if (this.returnCode == 0)
-			this.returnCode = 2;
-		else if (this.returnCode == 5) {
-			this.returnCode = 0;
-		}
-		this.targetAngle += 90;
-	}
-
-	/**
-	 * Shifts the focus to the previous menu item.
-	 */
-	private void previousMenuItem() {
-		SoundManager.play("sfx/menu_select.wav");
-		if (this.returnCode == 2)
-			this.returnCode = 0;
-		else if (this.returnCode == 0)
-			this.returnCode = 4;
-		else if (this.returnCode == 4)
-			this.returnCode = 6;
-		else if (this.returnCode == 6)
-			this.returnCode = 3;
-		else if (this.returnCode == 3)
-			this.returnCode = 2;
-		else if (this.returnCode == 5) {
-			this.returnCode = 6;
-		}
-		this.targetAngle -= 90;
-	}
-
-	/**
-	 * Draws the elements associated with the screen.
-	 */
-	private void draw() {
-		drawManager.initDrawing(this);
-
-		// Draw stars with rotation
-		drawManager.drawStars(this, this.stars, this.currentAngle);
-
-		// Draw shooting stars with rotation
-        drawManager.drawShootingStars(this, this.shootingStars, this.currentAngle);
-
-		// Draw background enemies with rotation
-		final double angleRad = Math.toRadians(this.currentAngle);
-        final double cosAngle = Math.cos(angleRad);
-        final double sinAngle = Math.sin(angleRad);
-        final int centerX = this.getWidth() / 2;
-        final int centerY = this.getHeight() / 2;
-
-		for (Entity enemy : this.backgroundEnemies) {
-			float relX = enemy.getPositionX() - centerX;
-            float relY = enemy.getPositionY() - centerY;
-
-            double rotatedX = relX * cosAngle - relY * sinAngle;
-            double rotatedY = relX * sinAngle + relY * cosAngle;
-
-            int screenX = (int) (rotatedX + centerX);
-            int screenY = (int) (rotatedY + centerY);
-
-			drawManager.drawEntity(enemy, screenX, screenY);
+			this.targetAngle += 90;
 		}
 
-		drawManager.drawTitle(this);
-		drawManager.drawMenu(this, this.returnCode);
-		drawManager.drawEntity(this.soundButton, this.width * 4 / 5 - 16,
-				this.height * 4 / 5 - 16);
+		/**
+		 * Shifts the focus to the previous menu item.
+		 */
+		private void previousMenuItem() {
+			SoundManager.play("sfx/menu_select.wav");
+			if (this.returnCode == 2)
+				this.returnCode = 0;
+			else if (this.returnCode == 0)
+				this.returnCode = 4;
+			else if (this.returnCode == 4)
+				this.returnCode = 6;
+			else if (this.returnCode == 6)
+				this.returnCode = 3;
+			else if (this.returnCode == 3)
+				this.returnCode = 2;
+			else if (this.returnCode == 5) {
+				this.returnCode = 6;
+			}
+			this.targetAngle -= 90;
+		}
 
-		drawManager.completeDrawing(this);
-	}
+		/**
+		 * Draws the elements associated with the screen.
+		 */
+		private void draw() {
+			drawManager.initDrawing(this);
 
-	/**
-	 * Getter for the sound state.
-	 * @return isSoundOn of the sound button.
-	 */
-	public boolean getIsSoundOn() {
-		return SoundButton.getIsSoundOn();
+			// Draw stars with rotation
+			drawManager.drawStars(this, this.stars, this.currentAngle);
+
+			// Draw shooting stars with rotation
+			drawManager.drawShootingStars(this, this.shootingStars, this.currentAngle);
+
+			// Draw background enemies with rotation
+			final double angleRad = Math.toRadians(this.currentAngle);
+			final double cosAngle = Math.cos(angleRad);
+			final double sinAngle = Math.sin(angleRad);
+			final int centerX = this.getWidth() / 2;
+			final int centerY = this.getHeight() / 2;
+
+			for (Entity enemy : this.backgroundEnemies) {
+				float relX = enemy.getPositionX() - centerX;
+				float relY = enemy.getPositionY() - centerY;
+
+				double rotatedX = relX * cosAngle - relY * sinAngle;
+				double rotatedY = relX * sinAngle + relY * cosAngle;
+
+				int screenX = (int) (rotatedX + centerX);
+				int screenY = (int) (rotatedY + centerY);
+
+				drawManager.drawEntity(enemy, screenX, screenY);
+			}
+
+			drawManager.drawTitle(this);
+			drawManager.drawMenu(this, this.returnCode);
+			drawManager.drawEntity(this.soundButton, this.width * 4 / 5 - 16,
+					this.height * 4 / 5 - 16);
+
+			drawManager.completeDrawing(this);
+		}
+
+		/**
+		 * Getter for the sound state.
+		 * @return isSoundOn of the sound button.
+		 */
+		public boolean getIsSoundOn() {
+			return SoundButton.getIsSoundOn();
+		}
+
+		/**
+		 * Getter for the PlayerCount about 1p 2p.
+		 * @return 1 or 2 as 1p,2p
+		 */
+		public static int selectPlayerCount = 1;
+		public static int getSelectPlayerCount() {return selectPlayerCount;}
 	}
-}


### PR DESCRIPTION
feat: Implement 1P/2P selection feature logic implement

기존 스페이스 인베이더 코드는 2P로 고정되어 플레이되게 하드코딩 되었습니다. 
이를 유저가 1P와 2P로 나누어 플레이할 수 있도록 로직을 구현했습니다.

메인 메뉴상에서 플레이어가 1p 혹은 2p를 고를 시 이 값을 받아와 GameState 로 넘기고, 이를 이용해 2p 객체를 생성할지 말지 결정합니다.
TitleScrren.java 맨 아래 코드 부근에 selectPlayerCount = 1 로 두고 테스트를 진행했습니다.

메인 메뉴에서 1p, 2p 구현이 끝났을 시 이 변수에 값을 저장시키는 방식으로 동작하도록 구현하는 작업이 필요합니다.
