### PR TITLE
fix: fix overlay

### DIFF
--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -600,10 +600,7 @@ public class GameScreen extends Screen {
 			}
 		}
 
-        if (pauseManager != null && pauseManager.isPaused()) {
-            drawManager.drawPauseOverlay(this);
-            drawManager.drawPauseMenu(this, pauseManager.getMenuIndex());
-        }
+
 
 		for (LaserBeam beam : laserBeamManager.getBeams()) {
 			drawManager.drawLaserBeam(beam);
@@ -667,6 +664,12 @@ public class GameScreen extends Screen {
 					/ 12);
 			drawManager.drawHorizontalLine(this, this.height / 2 + this.height
 					/ 12);
+		}
+
+		// If paused, draw the overlay and menu on top of the frozen game screen.
+		if (this.pauseManager.isPaused()) {
+			drawManager.drawPauseOverlay(this);
+			drawManager.drawPauseMenu(this, this.pauseManager.getMenuIndex());
 		}
 
 		drawManager.completeDrawing(this);


### PR DESCRIPTION
This pull request refactors how the pause overlay and menu are drawn in the `GameScreen` class. The main change is moving the pause rendering logic to a later point in the `draw()` method, ensuring the pause overlay and menu are rendered on top of all other game elements for proper visual stacking.

Rendering logic improvements:

* Moved the pause overlay and menu drawing code to after all game elements are drawn in the `draw()` method of `GameScreen`, so the pause visuals appear above everything else. [[1]](diffhunk://#diff-2cb83b1e334bad77df1b4983953635325b87a363c4518f6d3e9679e48be0b648L603-R603) [[2]](diffhunk://#diff-2cb83b1e334bad77df1b4983953635325b87a363c4518f6d3e9679e48be0b648R669-R674)