### PR TITLE
feat: add settings screen

### DIFF
--- a/src/audio/SoundManager.java
+++ b/src/audio/SoundManager.java
@@ -10,9 +10,48 @@ public class SoundManager {
     private static final Map<String, Clip> CACHE = new ConcurrentHashMap<>();
     private static volatile boolean muted = false;  // global state of sound
     private static volatile String currentLooping = null;
+    private static float volume = 0.5f;
+
+    public static void setVolume(float vol) {
+        if (vol < 0.0f) vol = 0.0f;
+        if (vol > 1.0f) vol = 1.0f;
+        volume = vol;
+        updateAllVolumes();
+    }
+
+    public static float getVolume() {
+        return volume;
+    }
+
+    private static void updateAllVolumes() {
+        for (Clip c : CACHE.values()) {
+            setClipVolume(c);
+        }
+    }
+
+    private static void setClipVolume(Clip clip) {
+        if (clip == null) return;
+        try {
+            FloatControl gainControl = (FloatControl) clip.getControl(FloatControl.Type.MASTER_GAIN);
+            if (volume == 0.0f) {
+                gainControl.setValue(gainControl.getMinimum());
+            } else {
+                float range = gainControl.getMaximum() - gainControl.getMinimum();
+                float gain = (range * volume) + gainControl.getMinimum();
+                // Some safety margin
+                if (gain > gainControl.getMaximum()) {
+                    gain = gainControl.getMaximum();
+                }
+                gainControl.setValue(gain);
+            }
+        } catch (IllegalArgumentException e) {
+            // This can happen if the control is not supported.
+            // System.err.println("[Sound] Volume control not supported for a clip.");
+        }
+    }
 
     public static void play(String resourcePath) {
-        if (muted) return;  // no sound played
+        if (muted || volume == 0.0f) return;
         try {
             Clip c = CACHE.computeIfAbsent(resourcePath, SoundManager::loadClip);
             if (c == null) return;
@@ -32,6 +71,7 @@ public class SoundManager {
                  AudioInputStream ais = AudioSystem.getAudioInputStream(in)) {
                 Clip clip = AudioSystem.getClip();
                 clip.open(ais);
+                setClipVolume(clip); // Set volume on load
                 return clip;
             }
         } catch (Exception e) {
@@ -42,7 +82,7 @@ public class SoundManager {
 
 
     public static void playLoop(String resourcePath) {
-        if (muted) return;  // no sound played
+        if (muted || volume == 0.0f) return;
         try {
             Clip c = CACHE.computeIfAbsent(resourcePath, SoundManager::loadClip);
             if (c == null) return;
@@ -50,7 +90,7 @@ public class SoundManager {
             c.setFramePosition(0);
             c.loop(Clip.LOOP_CONTINUOUSLY);
             c.start();
-            currentLooping = resourcePath;  // useful for unmute
+            currentLooping = resourcePath;
         } catch (Exception e) {
             System.err.println("[Sound] Loop failed: " + resourcePath + " -> " + e.getMessage());
         }

--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -82,6 +82,9 @@ public final class Core {
 			e.printStackTrace();
 		}
 
+        // Initialize settings manager.
+        GameSettingsManager.getInstance();
+
 		frame = new Frame(WIDTH, HEIGHT);
 		DrawManager.getInstance().setFrame(frame);
 		int width = frame.getWidth();
@@ -258,15 +261,21 @@ public final class Core {
                     returnCode = frame.setScreen(currentScreen);
                     LOGGER.info("Closing achievement screen.");
                     break;
-				case 8: // (추가) CreditScreen
-					currentScreen = new CreditScreen(width, height, FPS);
-					LOGGER.info("Starting " + currentScreen.getClass().getSimpleName() + " screen.");
-					returnCode = frame.setScreen(currentScreen);
-					break;
-                default:
-                    break;
-            }
-
+				                case 8: // (추가) CreditScreen
+									currentScreen = new CreditScreen(width, height, FPS);
+									LOGGER.info("Starting " + currentScreen.getClass().getSimpleName() + " screen.");
+									returnCode = frame.setScreen(currentScreen);
+									break;
+				                case 9:
+				                    currentScreen = new SettingsScreen(width, height, FPS);
+				                    LOGGER.info("Starting " + WIDTH + "x" + HEIGHT
+				                            + " settings screen at " + FPS + " fps.");
+				                    returnCode = frame.setScreen(currentScreen);
+				                    LOGGER.info("Closing settings screen.");
+				                    break;
+				                default:
+				                    break;
+				            }
         } while (returnCode != 0);
 
         fileHandler.flush();

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -1,12 +1,14 @@
 package engine;
 
 import java.awt.*;
+import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import java.awt.event.KeyEvent;
 
 import entity.Entity;
 import entity.FinalBoss;
@@ -16,6 +18,7 @@ import engine.Achievement;
 import screen.CreditScreen;
 import screen.GameScreen;
 import screen.Screen;
+import screen.SettingsScreen;
 import engine.Score;
 import screen.TitleScreen;
 import screen.TitleScreen.Star;
@@ -460,6 +463,7 @@ public final class DrawManager {
 		String playString = "Play";
 		String highScoresString = "High scores";
 		String achievementsString = "Achievements";
+        String settingsString = "Settings";
 		String shopString = "Shop";
 		String exitString = "Exit";
 
@@ -479,14 +483,178 @@ public final class DrawManager {
 		else backBufferGraphics.setColor(Color.WHITE);
 		drawCenteredRegularString(screen, achievementsString, screen.getHeight() / 3 * 2 + fontRegularMetrics.getHeight() * 2);
 
+        if (option == 9) backBufferGraphics.setColor(pulseColor);
+        else backBufferGraphics.setColor(Color.WHITE);
+        drawCenteredRegularString(screen, settingsString, screen.getHeight() / 3 * 2 + fontRegularMetrics.getHeight() * 3);
+
 		if (option == 4) backBufferGraphics.setColor(pulseColor);
 		else backBufferGraphics.setColor(Color.WHITE);
-		drawCenteredRegularString(screen, shopString, screen.getHeight() / 3 * 2 + fontRegularMetrics.getHeight() * 3);
+		drawCenteredRegularString(screen, shopString, screen.getHeight() / 3 * 2 + fontRegularMetrics.getHeight() * 4);
 
 		if (option == 0) backBufferGraphics.setColor(pulseColor);
 		else backBufferGraphics.setColor(Color.WHITE);
-		drawCenteredRegularString(screen, exitString, screen.getHeight() / 3 * 2 + fontRegularMetrics.getHeight() * 4);
+		drawCenteredRegularString(screen, exitString, screen.getHeight() / 3 * 2 + fontRegularMetrics.getHeight() * 5);
 	}
+
+	public void drawModernSettings(final SettingsScreen screen, final SettingsScreen.EScreenState screenState, final int mainSelection, final int keyBindingSelection, final GameSettingsManager settingsManager, final boolean isRebinding, final int currentPlayer) {
+		// Enable anti-aliasing for smoother graphics
+		Graphics2D g2d = (Graphics2D) backBufferGraphics;
+		g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+	
+		// Draw Title
+		backBufferGraphics.setColor(Color.GREEN);
+		drawCenteredBigString(screen, "Settings", screen.getHeight() / 8);
+	
+		// Draw main menu items
+		String[] mainMenuItems = screen.getMainMenuItems();
+		int initialY = screen.getHeight() / 4;
+		int yStep = 60; // Increased step for more space overall
+		int extraSpaceAfterVolume = 30; // The specific gap
+	
+		for (int i = 0; i < mainMenuItems.length; i++) {
+			int currentY = initialY + i * yStep;
+			if (i >= 1) { // Apply space for items after "Volume"
+				currentY += extraSpaceAfterVolume;
+			}
+			
+			boolean isSelected = (i == mainSelection);
+			Color color = isSelected ? Color.GREEN : Color.WHITE;
+			
+			if (isSelected && screenState == SettingsScreen.EScreenState.MAIN_SELECTION) {
+				float pulse = (float) ((Math.sin(System.currentTimeMillis() / 200.0) + 1.0) / 2.0);
+				color = new Color(0, 0.5f + pulse * 0.5f, 0);
+			}
+			
+			backBufferGraphics.setColor(color);
+			backBufferGraphics.setFont(fontBig);
+			// Center align the text as requested
+			drawCenteredBigString(screen, mainMenuItems[i], currentY);
+	
+			if (i == 0) { // Volume
+				// The volume slider is now drawn below the text
+				drawVolumeSlider(screen, settingsManager.getVolume(), currentY, isSelected || screenState == SettingsScreen.EScreenState.VOLUME_ADJUST);
+			}
+		}
+	
+		// Handle sub-menus (Key Bindings)
+		if (screenState == SettingsScreen.EScreenState.KEY_BINDINGS) {
+			drawDimOverlay(screen);
+			drawKeyBindingPanel(screen, keyBindingSelection, settingsManager, isRebinding, currentPlayer, screen.getKeyBindingActions());
+		}
+	
+		if (isRebinding) {
+			drawRebindingOverlay(screen);
+		}
+		
+		// Draw footer instructions
+		drawFooterInstructions(screen, screenState);
+	}
+	
+	private void drawVolumeSlider(final Screen screen, float volume, int y, boolean isActive) {
+		int barWidth = 150;
+		int barHeight = 8;
+		int barX = screen.getWidth() / 2 - barWidth / 2; // Centered
+		int barY = y + 30; // Positioned below the "Volume" text
+		
+		// Draw bar background
+		backBufferGraphics.setColor(Color.DARK_GRAY);
+		backBufferGraphics.fillRoundRect(barX, barY, barWidth, barHeight, 8, 8);
+	
+		// Draw filled portion of the bar
+		backBufferGraphics.setColor(isActive ? Color.GREEN : new Color(0, 150, 0));
+		backBufferGraphics.fillRoundRect(barX, barY, (int) (barWidth * volume), barHeight, 8, 8);
+	
+		// Draw knob
+		int knobSize = 16;
+		int knobX = barX + (int) (barWidth * volume) - knobSize / 2;
+		int knobY = barY + barHeight / 2 - knobSize / 2;
+		backBufferGraphics.setColor(isActive ? Color.WHITE : Color.LIGHT_GRAY);
+		backBufferGraphics.fillOval(knobX, knobY, knobSize, knobSize);
+	
+		// Draw percentage
+		backBufferGraphics.setFont(fontRegular);
+		backBufferGraphics.setColor(isActive ? Color.WHITE : Color.GRAY);
+		String volPercent = String.format("%d%%", (int) (volume * 100));
+		// Position percentage above the bar
+		backBufferGraphics.drawString(volPercent, barX + barWidth / 2 - fontRegularMetrics.stringWidth(volPercent) / 2, barY - 10);
+	}
+	
+	private void drawKeyBindingPanel(final Screen screen, final int selection, final GameSettingsManager settingsManager, final boolean isRebinding, final int player, final String[] actions) {
+		int panelWidth = 380;
+		int panelHeight = 280;
+		int panelX = (screen.getWidth() - panelWidth) / 2;
+		int panelY = (screen.getHeight() - panelHeight) / 2;
+	
+		// Draw panel background
+		backBufferGraphics.setColor(new Color(20, 20, 30, 240));
+		backBufferGraphics.fillRoundRect(panelX, panelY, panelWidth, panelHeight, 15, 15);
+		backBufferGraphics.setColor(Color.GREEN);
+		backBufferGraphics.drawRoundRect(panelX, panelY, panelWidth, panelHeight, 15, 15);
+	
+		// Panel Title
+		backBufferGraphics.setFont(fontBig);
+		String title = "Player " + player + " Controls";
+		int titleWidth = fontBigMetrics.stringWidth(title);
+		backBufferGraphics.drawString(title, panelX + (panelWidth - titleWidth) / 2, panelY + 40);
+	
+		// Draw key bindings list
+		int listY = panelY + 80;
+		int yStep = 35;
+		backBufferGraphics.setFont(fontRegular);
+	
+		for (int i = 0; i < actions.length; i++) {
+			boolean isSelected = (i == selection);
+			Color color = isSelected ? Color.GREEN : Color.WHITE;
+			
+			if (isSelected) {
+				float pulse = (float) ((Math.sin(System.currentTimeMillis() / 200.0) + 1.0) / 2.0);
+				color = new Color(0.5f, 0.8f + pulse * 0.2f, 0.5f);
+			}
+	
+			backBufferGraphics.setColor(color);
+			String action = actions[i];
+			String key = (player == 1) ? KeyEvent.getKeyText(settingsManager.getKey(action)) : KeyEvent.getKeyText(settingsManager.getKeyP2(action));
+			
+			backBufferGraphics.drawString(action, panelX + 40, listY + i * yStep);
+			backBufferGraphics.drawString(key, panelX + panelWidth - 100, listY + i * yStep);
+		}
+	}
+	
+	private void drawRebindingOverlay(final Screen screen) {
+		drawDimOverlay(screen);
+		backBufferGraphics.setFont(fontBig);
+		backBufferGraphics.setColor(Color.YELLOW);
+		drawCenteredBigString(screen, "Press any key to bind...", screen.getHeight() / 2);
+	}
+	
+	private void drawDimOverlay(final Screen screen) {
+		backBufferGraphics.setColor(new Color(0, 0, 0, 180));
+		backBufferGraphics.fillRect(0, 0, screen.getWidth(), screen.getHeight()); 
+	}
+	
+	private void drawFooterInstructions(final Screen screen, final screen.SettingsScreen.EScreenState state) {
+		backBufferGraphics.setFont(fontRegular);
+		backBufferGraphics.setColor(Color.GRAY);
+		String instructions = "";
+		switch (state) {
+			case MAIN_SELECTION:
+				instructions = "UP/DOWN: Navigate | SHOOT: Select";
+				break;
+			case VOLUME_ADJUST:
+				instructions = "LEFT/RIGHT: Adjust Volume | SHOOT/ESC: Back";
+				break;
+			case KEY_BINDINGS:
+				instructions = "UP/DOWN: Navigate | SHOOT: Rebind | ESC: Back";
+				break;
+		}
+		drawCenteredRegularString(screen, instructions, screen.getHeight() - 30);
+	}
+
+    // Helper method to draw a centered string within a given width
+    private void drawCenteredRegularString(final Screen screen, final String string, final int height, final int startX, final int width) {
+        backBufferGraphics.setFont(fontRegular);
+        backBufferGraphics.drawString(string, startX + width / 2 - fontRegularMetrics.stringWidth(string) / 2, height);
+    }
 
 	/**
 	 * Draws game results.

--- a/src/engine/GameSettingsManager.java
+++ b/src/engine/GameSettingsManager.java
@@ -1,0 +1,128 @@
+package engine;
+
+import java.awt.event.KeyEvent;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import audio.SoundManager;
+
+public class GameSettingsManager {
+
+    private static GameSettingsManager instance;
+    private static final String SETTINGS_FILE = "settings.properties";
+
+    private float volume;
+    private Map<String, Integer> keyBindings;
+    private Map<String, Integer> keyBindingsP2;
+
+    private GameSettingsManager() {
+        loadSettings();
+    }
+
+    public static synchronized GameSettingsManager getInstance() {
+        if (instance == null) {
+            instance = new GameSettingsManager();
+        }
+        return instance;
+    }
+
+    public float getVolume() {
+        return volume;
+    }
+
+    public void setVolume(float volume) {
+        this.volume = volume;
+        SoundManager.setVolume(this.volume);
+        saveSettings();
+    }
+
+    public int getKey(String action) {
+        return keyBindings.getOrDefault(action, -1);
+    }
+
+    public int getKeyP2(String action) {
+        return keyBindingsP2.getOrDefault(action, -1);
+    }
+
+    public void setKey(String action, int keyCode) {
+        keyBindings.put(action, keyCode);
+        saveSettings();
+    }
+
+    public void setKeyP2(String action, int keyCode) {
+        keyBindingsP2.put(action, keyCode);
+        saveSettings();
+    }
+
+    public Map<String, Integer> getKeyBindings() {
+        return keyBindings;
+    }
+
+    public Map<String, Integer> getKeyBindingsP2() {
+        return keyBindingsP2;
+    }
+
+    private void loadSettings() {
+        Properties props = new Properties();
+        try (FileReader reader = new FileReader(SETTINGS_FILE)) {
+            props.load(reader);
+            this.volume = Float.parseFloat(props.getProperty("volume", "0.5"));
+            this.keyBindings = new HashMap<>();
+            this.keyBindings.put("UP", Integer.parseInt(props.getProperty("P1_UP", String.valueOf(KeyEvent.VK_W))));
+            this.keyBindings.put("DOWN", Integer.parseInt(props.getProperty("P1_DOWN", String.valueOf(KeyEvent.VK_S))));
+            this.keyBindings.put("LEFT", Integer.parseInt(props.getProperty("P1_LEFT", String.valueOf(KeyEvent.VK_A))));
+            this.keyBindings.put("RIGHT", Integer.parseInt(props.getProperty("P1_RIGHT", String.valueOf(KeyEvent.VK_D))));
+            this.keyBindings.put("SHOOT", Integer.parseInt(props.getProperty("P1_SHOOT", String.valueOf(KeyEvent.VK_SPACE))));
+            this.keyBindingsP2 = new HashMap<>();
+            this.keyBindingsP2.put("UP", Integer.parseInt(props.getProperty("P2_UP", String.valueOf(KeyEvent.VK_UP))));
+            this.keyBindingsP2.put("DOWN", Integer.parseInt(props.getProperty("P2_DOWN", String.valueOf(KeyEvent.VK_DOWN))));
+            this.keyBindingsP2.put("LEFT", Integer.parseInt(props.getProperty("P2_LEFT", String.valueOf(KeyEvent.VK_LEFT))));
+            this.keyBindingsP2.put("RIGHT", Integer.parseInt(props.getProperty("P2_RIGHT", String.valueOf(KeyEvent.VK_RIGHT))));
+            this.keyBindingsP2.put("SHOOT", Integer.parseInt(props.getProperty("P2_SHOOT", String.valueOf(KeyEvent.VK_ENTER))));
+        } catch (IOException e) {
+            // File not found, use default settings
+            setDefaultSettings();
+        }
+        SoundManager.setVolume(this.volume);
+    }
+
+    private void saveSettings() {
+        Properties props = new Properties();
+        props.setProperty("volume", String.valueOf(this.volume));
+        props.setProperty("P1_UP", String.valueOf(this.keyBindings.get("UP")));
+        props.setProperty("P1_DOWN", String.valueOf(this.keyBindings.get("DOWN")));
+        props.setProperty("P1_LEFT", String.valueOf(this.keyBindings.get("LEFT")));
+        props.setProperty("P1_RIGHT", String.valueOf(this.keyBindings.get("RIGHT")));
+        props.setProperty("P1_SHOOT", String.valueOf(this.keyBindings.get("SHOOT")));
+        props.setProperty("P2_UP", String.valueOf(this.keyBindingsP2.get("UP")));
+        props.setProperty("P2_DOWN", String.valueOf(this.keyBindingsP2.get("DOWN")));
+        props.setProperty("P2_LEFT", String.valueOf(this.keyBindingsP2.get("LEFT")));
+        props.setProperty("P2_RIGHT", String.valueOf(this.keyBindingsP2.get("RIGHT")));
+        props.setProperty("P2_SHOOT", String.valueOf(this.keyBindingsP2.get("SHOOT")));
+
+        try (FileWriter writer = new FileWriter(SETTINGS_FILE)) {
+            props.store(writer, "Game Settings");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void setDefaultSettings() {
+        this.volume = 0.5f;
+        this.keyBindings = new HashMap<>();
+        this.keyBindings.put("UP", KeyEvent.VK_W);
+        this.keyBindings.put("DOWN", KeyEvent.VK_S);
+        this.keyBindings.put("LEFT", KeyEvent.VK_A);
+        this.keyBindings.put("RIGHT", KeyEvent.VK_D);
+        this.keyBindings.put("SHOOT", KeyEvent.VK_SPACE);
+        this.keyBindingsP2 = new HashMap<>();
+        this.keyBindingsP2.put("UP", KeyEvent.VK_UP);
+        this.keyBindingsP2.put("DOWN", KeyEvent.VK_DOWN);
+        this.keyBindingsP2.put("LEFT", KeyEvent.VK_LEFT);
+        this.keyBindingsP2.put("RIGHT", KeyEvent.VK_RIGHT);
+        this.keyBindingsP2.put("SHOOT", KeyEvent.VK_ENTER);
+    }
+}

--- a/src/engine/InputManager.java
+++ b/src/engine/InputManager.java
@@ -17,12 +17,15 @@ public final class InputManager implements KeyListener {
 	private static boolean[] keys;
 	/** Singleton instance of the class. */
 	private static InputManager instance;
+    /** Last key code pressed. */
+    private int lastKeyCode;
 
 	/**
 	 * Private constructor.
 	 */
 	private InputManager() {
 		keys = new boolean[NUM_KEYS];
+        this.lastKeyCode = -1;
 	}
 
 	/**
@@ -47,6 +50,28 @@ public final class InputManager implements KeyListener {
 		return keys[keyCode];
 	}
 
+    public boolean isActionPressed(String action) {
+        GameSettingsManager settings = GameSettingsManager.getInstance();
+        return isKeyDown(settings.getKey(action));
+    }
+
+    public boolean isActionPressedP2(String action) {
+        GameSettingsManager settings = GameSettingsManager.getInstance();
+        return isKeyDown(settings.getKeyP2(action));
+    }
+
+    public boolean menuInput(String action) {
+        return isActionPressed(action) || isActionPressedP2(action);
+    }
+
+    public int getLastKeyCode() {
+        return this.lastKeyCode;
+    }
+
+    public void clearLastKeyCode() {
+        this.lastKeyCode = -1;
+    }
+
 	/**
 	 * Changes the state of the key to pressed.
 	 * 
@@ -57,6 +82,7 @@ public final class InputManager implements KeyListener {
 	public void keyPressed(final KeyEvent key) {
 		if (key.getKeyCode() >= 0 && key.getKeyCode() < NUM_KEYS)
 			keys[key.getKeyCode()] = true;
+        this.lastKeyCode = key.getKeyCode();
 	}
 
 	/**
@@ -80,13 +106,5 @@ public final class InputManager implements KeyListener {
 	@Override
 	public void keyTyped(final KeyEvent key) {
 
-	}
-
-	public boolean isP1KeyDown(int keyCode) {
-		return isKeyDown(keyCode);
-	}
-
-	public boolean isP2KeyDown(int keyCode) {
-		return isKeyDown(keyCode);
 	}
 }

--- a/src/screen/CreditScreen.java
+++ b/src/screen/CreditScreen.java
@@ -85,7 +85,7 @@ public class CreditScreen extends Screen {
         super.update();
         draw();
         // Pressing the spacebar will exit the screen.
-        if (inputManager.isKeyDown(KeyEvent.VK_SPACE) && this.inputDelay.checkFinished()) {
+        if (inputManager.menuInput("SHOOT") && this.inputDelay.checkFinished()) {
             this.isRunning = false;
         }
     }

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -331,11 +331,11 @@ public class GameScreen extends Screen {
 			}
 
 			if (this.livesP1 > 0 && !this.ship.isDestroyed()) {
-				boolean p1Right = inputManager.isP1KeyDown(KeyEvent.VK_D);
-				boolean p1Left = inputManager.isP1KeyDown(KeyEvent.VK_A);
-				boolean p1Up = inputManager.isP1KeyDown(KeyEvent.VK_W);
-				boolean p1Down = inputManager.isP1KeyDown(KeyEvent.VK_S);
-				boolean p1Fire = inputManager.isP1KeyDown(KeyEvent.VK_SPACE);
+				boolean p1Right = inputManager.isActionPressed("RIGHT");
+				boolean p1Left = inputManager.isActionPressed("LEFT");
+				boolean p1Up = inputManager.isActionPressed("UP");
+				boolean p1Down = inputManager.isActionPressed("DOWN");
+				boolean p1Fire = inputManager.isActionPressed("SHOOT");
 
 				boolean isRightBorder = this.ship.getPositionX()
 						+ this.ship.getWidth() + this.ship.getSpeed() > this.width - 1;
@@ -358,11 +358,11 @@ public class GameScreen extends Screen {
 			}
 
 			if (this.shipP2 != null && this.livesP2 > 0 && !this.shipP2.isDestroyed()) {
-				boolean p2Right = inputManager.isP2KeyDown(KeyEvent.VK_RIGHT);
-				boolean p2Left = inputManager.isP2KeyDown(KeyEvent.VK_LEFT);
-				boolean p2Up = inputManager.isP2KeyDown(KeyEvent.VK_UP);
-				boolean p2Down = inputManager.isP2KeyDown(KeyEvent.VK_DOWN);
-				boolean p2Fire = inputManager.isP2KeyDown(KeyEvent.VK_ENTER);
+				boolean p2Right = inputManager.isActionPressedP2("RIGHT");
+				boolean p2Left = inputManager.isActionPressedP2("LEFT");
+				boolean p2Up = inputManager.isActionPressedP2("UP");
+				boolean p2Down = inputManager.isActionPressedP2("DOWN");
+				boolean p2Fire = inputManager.isActionPressedP2("SHOOT");
 
 				boolean p2RightBorder = this.shipP2.getPositionX()
 						+ this.shipP2.getWidth() + this.shipP2.getSpeed() > this.width - 1;

--- a/src/screen/HighScoreScreen.java
+++ b/src/screen/HighScoreScreen.java
@@ -58,7 +58,7 @@ public class HighScoreScreen extends Screen {
 		super.update();
 
 		draw();
-		if (inputManager.isKeyDown(KeyEvent.VK_SPACE)
+		if (inputManager.menuInput("SHOOT")
 				&& this.inputDelay.checkFinished())
 			this.isRunning = false;
 	}

--- a/src/screen/ModeSelectScreen.java
+++ b/src/screen/ModeSelectScreen.java
@@ -126,9 +126,8 @@ public class ModeSelectScreen extends Screen {
             return;
         }
         if (!this.inputArmed) {
-            boolean enterDown = inputManager.isKeyDown(KeyEvent.VK_ENTER);
-            boolean spaceDown = inputManager.isKeyDown(KeyEvent.VK_SPACE);
-            if (!enterDown && !spaceDown) {
+            boolean confirmPressed = inputManager.menuInput("SHOOT");
+            if (!confirmPressed) {
                 this.inputArmed = true;
             }
             draw();
@@ -137,11 +136,11 @@ public class ModeSelectScreen extends Screen {
 
         // ---- Navigation: once per cooldown, like TitleScreen ----
         if (this.selectionCooldown.checkFinished()) {
-            if (inputManager.isKeyDown(KeyEvent.VK_UP) || inputManager.isKeyDown(KeyEvent.VK_W)) {
+            if (inputManager.menuInput("UP")) {
                 this.selection = (this.selection - 1 + 3) % 3; // 0↔1↔2
                 this.targetAngle -= 90;
                 this.selectionCooldown.reset();
-            } else if (inputManager.isKeyDown(KeyEvent.VK_DOWN) || inputManager.isKeyDown(KeyEvent.VK_S)) {
+            } else if (inputManager.menuInput("DOWN")) {
                 this.selection = (this.selection + 1) % 3;
                 this.targetAngle += 90;
                 this.selectionCooldown.reset();
@@ -154,8 +153,7 @@ public class ModeSelectScreen extends Screen {
             return;
         }
 
-        if (inputManager.isKeyDown(KeyEvent.VK_ENTER)
-                || inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
+        if (inputManager.menuInput("SHOOT")) {
             if (this.selection == 0) this.selectedMode = "1P";
             else if (this.selection == 1) this.selectedMode = "2P";
             else this.selectedMode = "CANCEL";

--- a/src/screen/PauseManager.java
+++ b/src/screen/PauseManager.java
@@ -30,22 +30,21 @@ public class PauseManager {
     public void update(InputManager input) {
 
         // ↑
-        boolean up = input.isKeyDown(KeyEvent.VK_UP);
+        boolean up = input.menuInput("UP");
         if (up && !upLast) {
             menuIndex = (menuIndex + 2) % 3;
         }
         upLast = up;
 
         // ↓
-        boolean down = input.isKeyDown(KeyEvent.VK_DOWN);
+        boolean down = input.menuInput("DOWN");
         if (down && !downLast) {
             menuIndex = (menuIndex + 1) % 3;
         }
         downLast = down;
 
         // ENTER or SPACE
-        boolean confirm = input.isKeyDown(KeyEvent.VK_ENTER) ||
-                input.isKeyDown(KeyEvent.VK_SPACE);
+        boolean confirm = input.menuInput("SHOOT");
 
         if (confirm && !confirmLast) {
             if (menuIndex == 0)      wantQuit = true;

--- a/src/screen/ScoreScreen.java
+++ b/src/screen/ScoreScreen.java
@@ -109,7 +109,7 @@ public class ScoreScreen extends Screen {
 				this.isRunning = false;
 				if (this.isNewRecord)
 					saveScore();
-			} else if (inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
+			} else if (inputManager.menuInput("SHOOT")) {
 				// Play again.
 				this.returnCode = 2;
 				this.isRunning = false;
@@ -118,24 +118,24 @@ public class ScoreScreen extends Screen {
 			}
 
 			if (this.isNewRecord && this.selectionCooldown.checkFinished()) {
-				if (inputManager.isKeyDown(KeyEvent.VK_RIGHT)) {
+				if (inputManager.menuInput("RIGHT")) {
 					this.nameCharSelected = this.nameCharSelected == 2 ? 0
 							: this.nameCharSelected + 1;
 					this.selectionCooldown.reset();
 				}
-				if (inputManager.isKeyDown(KeyEvent.VK_LEFT)) {
+				if (inputManager.menuInput("LEFT")) {
 					this.nameCharSelected = this.nameCharSelected == 0 ? 2
 							: this.nameCharSelected - 1;
 					this.selectionCooldown.reset();
 				}
-				if (inputManager.isKeyDown(KeyEvent.VK_UP)) {
+				if (inputManager.menuInput("UP")) {
 					this.name[this.nameCharSelected] =
 							(char) (this.name[this.nameCharSelected]
 									== LAST_CHAR ? FIRST_CHAR
 							: this.name[this.nameCharSelected] + 1);
 					this.selectionCooldown.reset();
 				}
-				if (inputManager.isKeyDown(KeyEvent.VK_DOWN)) {
+				if (inputManager.menuInput("DOWN")) {
 					this.name[this.nameCharSelected] =
 							(char) (this.name[this.nameCharSelected]
 									== FIRST_CHAR ? LAST_CHAR

--- a/src/screen/SettingsScreen.java
+++ b/src/screen/SettingsScreen.java
@@ -1,0 +1,179 @@
+package screen;
+
+import java.awt.event.KeyEvent;
+import java.util.Map;
+
+import engine.GameSettingsManager;
+import engine.Core;
+import engine.Cooldown;
+
+public class SettingsScreen extends Screen {
+
+    private static final int SELECTION_TIME = 150;
+
+    public enum EScreenState {
+        MAIN_SELECTION,
+        VOLUME_ADJUST,
+        KEY_BINDINGS
+    }
+
+    private EScreenState screenState;
+
+    private Cooldown selectionCooldown;
+    private GameSettingsManager settingsManager;
+
+    // Main menu
+    private String[] mainMenuItems = {"Volume", "Player 1 Controls", "Player 2 Controls", "Back"};
+    private int mainSelection;
+
+    // Key bindings
+    private String[] keyBindingActions = {"UP", "DOWN", "LEFT", "RIGHT", "SHOOT"};
+    private int keyBindingSelection;
+    private boolean isRebinding = false;
+    private int currentPlayer; // 1 for P1, 2 for P2
+
+    public SettingsScreen(final int width, final int height, final int fps) {
+        super(width, height, fps);
+        this.returnCode = 1; // Default return to title
+        this.settingsManager = GameSettingsManager.getInstance();
+        this.selectionCooldown = Core.getCooldown(SELECTION_TIME);
+        this.screenState = EScreenState.MAIN_SELECTION;
+        this.mainSelection = 0;
+        this.keyBindingSelection = 0;
+    }
+
+    @Override
+    public final int run() {
+        super.run();
+        return this.returnCode;
+    }
+
+    @Override
+    protected final void update() {
+        super.update();
+        draw();
+
+        if (this.selectionCooldown.checkFinished() && this.inputDelay.checkFinished()) {
+            if (isRebinding) {
+                handleRebindingInput();
+            } else {
+                switch (this.screenState) {
+                    case MAIN_SELECTION:
+                        handleMainSelectionInput();
+                        break;
+                    case VOLUME_ADJUST:
+                        handleVolumeAdjustInput();
+                        break;
+                    case KEY_BINDINGS:
+                        handleKeyBindingsInput();
+                        break;
+                }
+            }
+        }
+    }
+
+    private void handleMainSelectionInput() {
+        if (inputManager.menuInput("UP")) {
+            this.mainSelection = (this.mainSelection - 1 + mainMenuItems.length) % mainMenuItems.length;
+            this.selectionCooldown.reset();
+        } else if (inputManager.menuInput("DOWN")) {
+            this.mainSelection = (this.mainSelection + 1) % mainMenuItems.length;
+            this.selectionCooldown.reset();
+        } else if (inputManager.menuInput("SHOOT")) {
+            switch (this.mainSelection) {
+                case 0: // Volume
+                    this.screenState = EScreenState.VOLUME_ADJUST;
+                    break;
+                case 1: // Player 1
+                    this.screenState = EScreenState.KEY_BINDINGS;
+                    this.currentPlayer = 1;
+                    this.keyBindingSelection = 0;
+                    break;
+                case 2: // Player 2
+                    this.screenState = EScreenState.KEY_BINDINGS;
+                    this.currentPlayer = 2;
+                    this.keyBindingSelection = 0;
+                    break;
+                case 3: // Back
+                    this.isRunning = false;
+                    break;
+            }
+            this.selectionCooldown.reset();
+        }
+    }
+
+    private void handleVolumeAdjustInput() {
+        float volume = settingsManager.getVolume();
+        if (inputManager.menuInput("LEFT")) {
+            volume -= 0.05f;
+            if (volume < 0) volume = 0;
+            settingsManager.setVolume(volume);
+            this.selectionCooldown.reset();
+        } else if (inputManager.menuInput("RIGHT")) {
+            volume += 0.05f;
+            if (volume > 1.0f) volume = 1.0f;
+            settingsManager.setVolume(volume);
+            this.selectionCooldown.reset();
+        } else if (inputManager.menuInput("SHOOT") || inputManager.isKeyDown(KeyEvent.VK_ESCAPE)) {
+            this.screenState = EScreenState.MAIN_SELECTION;
+            this.selectionCooldown.reset();
+        }
+    }
+
+    private void handleKeyBindingsInput() {
+        if (inputManager.menuInput("UP")) {
+            this.keyBindingSelection = (this.keyBindingSelection - 1 + keyBindingActions.length) % keyBindingActions.length;
+            this.selectionCooldown.reset();
+        } else if (inputManager.menuInput("DOWN")) {
+            this.keyBindingSelection = (this.keyBindingSelection + 1) % keyBindingActions.length;
+            this.selectionCooldown.reset();
+        } else if (inputManager.menuInput("SHOOT")) {
+            this.isRebinding = true;
+            inputManager.clearLastKeyCode();
+            this.selectionCooldown.reset();
+        } else if (inputManager.isKeyDown(KeyEvent.VK_ESCAPE)) {
+            this.screenState = EScreenState.MAIN_SELECTION;
+            this.selectionCooldown.reset();
+        }
+    }
+
+    private void handleRebindingInput() {
+        int keyCode = inputManager.getLastKeyCode();
+        if (keyCode != -1) {
+            rebindKey(keyCode);
+            this.isRebinding = false;
+            inputManager.clearLastKeyCode();
+            this.selectionCooldown.reset();
+        }
+    }
+
+    private void rebindKey(int keyCode) {
+        String actionToRebind = keyBindingActions[keyBindingSelection];
+        Map<String, Integer> currentBindings = (this.currentPlayer == 1) ? settingsManager.getKeyBindings() : settingsManager.getKeyBindingsP2();
+
+        // Check for duplicates
+        for (Map.Entry<String, Integer> entry : currentBindings.entrySet()) {
+            if (entry.getValue() == keyCode && !entry.getKey().equals(actionToRebind)) {
+                // Key is already in use. Maybe show a message? For now, just ignore.
+                return;
+            }
+        }
+
+        if (this.currentPlayer == 1) {
+            settingsManager.setKey(actionToRebind, keyCode);
+        } else {
+            settingsManager.setKeyP2(actionToRebind, keyCode);
+        }
+    }
+
+    private void draw() {
+        drawManager.initDrawing(this);
+        // This will be a new method with the modern UI
+        drawManager.drawModernSettings(this, screenState, mainSelection, keyBindingSelection, settingsManager, isRebinding, currentPlayer);
+        drawManager.completeDrawing(this);
+    }
+
+    // Getters for the DrawManager
+    public String[] getMainMenuItems() { return mainMenuItems; }
+    public String[] getKeyBindingActions() { return keyBindingActions; }
+}

--- a/src/screen/ShopScreen.java
+++ b/src/screen/ShopScreen.java
@@ -152,21 +152,19 @@ public class ShopScreen extends Screen {
      */
     private void handleItemSelection() {
         // Navigate up
-        if (inputManager.isKeyDown(KeyEvent.VK_UP)
-                || inputManager.isKeyDown(KeyEvent.VK_W)) {
+        if (inputManager.menuInput("UP")) {
             previousItem();
             this.selectionCooldown.reset();
         }
 
         // Navigate down
-        if (inputManager.isKeyDown(KeyEvent.VK_DOWN)
-                || inputManager.isKeyDown(KeyEvent.VK_S)) {
+        if (inputManager.menuInput("DOWN")) {
             nextItem();
             this.selectionCooldown.reset();
         }
 
         // Select item (enter level selection)
-        if (inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
+        if (inputManager.menuInput("SHOOT")) {
             if (selectedItem == TOTAL_ITEMS) {
                 // Exit option selected
                 this.isRunning = false;
@@ -192,8 +190,7 @@ public class ShopScreen extends Screen {
      */
     private void handleLevelSelection() {
         // Navigate left (decrease level)
-        if (inputManager.isKeyDown(KeyEvent.VK_LEFT)
-                || inputManager.isKeyDown(KeyEvent.VK_A)) {
+        if (inputManager.menuInput("LEFT")) {
             if (selectedLevel > 1) {
                 selectedLevel--;
             }
@@ -201,8 +198,7 @@ public class ShopScreen extends Screen {
         }
 
         // Navigate right (increase level)
-        if (inputManager.isKeyDown(KeyEvent.VK_RIGHT)
-                || inputManager.isKeyDown(KeyEvent.VK_D)) {
+        if (inputManager.menuInput("RIGHT")) {
             if (selectedLevel < MAX_LEVELS[selectedItem]) {
                 selectedLevel++;
             }
@@ -210,7 +206,7 @@ public class ShopScreen extends Screen {
         }
 
         // Confirm purchase
-        if (inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
+        if (inputManager.menuInput("SHOOT")) {
             purchaseItem(selectedItem, selectedLevel);
             this.selectionCooldown.reset();
         }

--- a/src/screen/TitleScreen.java
+++ b/src/screen/TitleScreen.java
@@ -249,17 +249,15 @@ public class TitleScreen extends Screen {
 		draw();
 		if (this.selectionCooldown.checkFinished()
 				&& this.inputDelay.checkFinished()) {
-			if (inputManager.isKeyDown(KeyEvent.VK_UP)
-					|| inputManager.isKeyDown(KeyEvent.VK_W)) {
+			if (inputManager.menuInput("UP")) {
 				previousMenuItem();
 				this.selectionCooldown.reset();
 			}
-			if (inputManager.isKeyDown(KeyEvent.VK_DOWN)
-					|| inputManager.isKeyDown(KeyEvent.VK_S)) {
+			if (inputManager.menuInput("DOWN")) {
 				nextMenuItem();
 				this.selectionCooldown.reset();
 			}
-			if (inputManager.isKeyDown(KeyEvent.VK_SPACE)){
+			if (inputManager.menuInput("SHOOT")){
 				if (this.returnCode != 5) {
 					this.isRunning = false;
 				} else {
@@ -279,14 +277,12 @@ public class TitleScreen extends Screen {
 					}
 				}
 			}
-			if (inputManager.isKeyDown(KeyEvent.VK_RIGHT)
-					|| inputManager.isKeyDown(KeyEvent.VK_D)) {
+			if (inputManager.menuInput("RIGHT")) {
 				this.returnCode = 5;
 				this.targetAngle += 90;
 				this.selectionCooldown.reset();
 			}
-			if (this.returnCode == 5 && inputManager.isKeyDown(KeyEvent.VK_LEFT)
-					|| inputManager.isKeyDown(KeyEvent.VK_A)) {
+			if (this.returnCode == 5 && inputManager.menuInput("LEFT")) {
 				this.returnCode = 4;
 				this.targetAngle -= 90;
 				this.selectionCooldown.reset();
@@ -304,6 +300,8 @@ public class TitleScreen extends Screen {
 		else if (this.returnCode == 3)
 			this.returnCode = 6;
 		else if (this.returnCode == 6)
+			this.returnCode = 9;
+		else if (this.returnCode == 9)
 			this.returnCode = 4;
 		else if (this.returnCode == 4)
 			this.returnCode = 0;
@@ -325,6 +323,8 @@ public class TitleScreen extends Screen {
 		else if (this.returnCode == 0)
 			this.returnCode = 4;
 		else if (this.returnCode == 4)
+			this.returnCode = 9;
+		else if (this.returnCode == 9)
 			this.returnCode = 6;
 		else if (this.returnCode == 6)
 			this.returnCode = 3;

--- a/test/audio/SoundManagerTest.java
+++ b/test/audio/SoundManagerTest.java
@@ -1,0 +1,48 @@
+package audio;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SoundManagerTest {
+
+    private float originalVolume;
+
+    @BeforeEach
+    void setUp() {
+        originalVolume = SoundManager.getVolume();
+        // Ensure sound is not muted before each test
+        SoundManager.uncutAllSound();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Restore original volume
+        SoundManager.setVolume(originalVolume);
+        SoundManager.stopAll();
+        // Reset mute state
+        SoundManager.uncutAllSound();
+    }
+
+    @Test
+    void testSetAndGetVolume() {
+        SoundManager.setVolume(0.75f);
+        assertEquals(0.75f, SoundManager.getVolume(), 0.001, "Volume should be set to 0.75");
+
+        SoundManager.setVolume(0.0f);
+        assertEquals(0.0f, SoundManager.getVolume(), 0.001, "Volume should be set to 0.0");
+
+        SoundManager.setVolume(1.0f);
+        assertEquals(1.0f, SoundManager.getVolume(), 0.001, "Volume should be set to 1.0");
+    }
+
+    @Test
+    void testVolumeClamping() {
+        SoundManager.setVolume(1.5f);
+        assertEquals(1.0f, SoundManager.getVolume(), 0.001, "Volume should be clamped to 1.0");
+
+        SoundManager.setVolume(-0.5f);
+        assertEquals(0.0f, SoundManager.getVolume(), 0.001, "Volume should be clamped to 0.0");
+    }
+}

--- a/test/engine/GameSettingsManagerTest.java
+++ b/test/engine/GameSettingsManagerTest.java
@@ -1,0 +1,109 @@
+package engine;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GameSettingsManagerTest {
+
+    private static final String SETTINGS_FILE = "settings.properties";
+    private GameSettingsManager settingsManager;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Reset the singleton instance before each test using reflection.
+        Field instance = GameSettingsManager.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+
+        // Ensure there's no settings file from previous runs.
+        deleteSettingsFile();
+        settingsManager = GameSettingsManager.getInstance();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Clean up the created settings file.
+        deleteSettingsFile();
+    }
+
+    private void deleteSettingsFile() {
+        try {
+            Files.deleteIfExists(Paths.get(SETTINGS_FILE));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    void testGetInstance() {
+        assertNotNull(settingsManager, "getInstance should not return null.");
+        GameSettingsManager anotherInstance = GameSettingsManager.getInstance();
+        assertSame(settingsManager, anotherInstance, "getInstance should return the same instance.");
+    }
+
+    @Test
+    void testDefaultSettings() {
+        // When no file exists, default settings should be loaded.
+        assertEquals(0.5f, settingsManager.getVolume());
+        assertEquals(KeyEvent.VK_W, settingsManager.getKey("UP"));
+        assertEquals(KeyEvent.VK_S, settingsManager.getKey("DOWN"));
+        assertEquals(KeyEvent.VK_A, settingsManager.getKey("LEFT"));
+        assertEquals(KeyEvent.VK_D, settingsManager.getKey("RIGHT"));
+        assertEquals(KeyEvent.VK_SPACE, settingsManager.getKey("SHOOT"));
+        // P2
+        assertEquals(KeyEvent.VK_UP, settingsManager.getKeyP2("UP"));
+        assertEquals(KeyEvent.VK_DOWN, settingsManager.getKeyP2("DOWN"));
+        assertEquals(KeyEvent.VK_LEFT, settingsManager.getKeyP2("LEFT"));
+        assertEquals(KeyEvent.VK_RIGHT, settingsManager.getKeyP2("RIGHT"));
+        assertEquals(KeyEvent.VK_ENTER, settingsManager.getKeyP2("SHOOT"));
+    }
+
+    @Test
+    void testSetAndGetVolume() {
+        settingsManager.setVolume(0.8f);
+        assertEquals(0.8f, settingsManager.getVolume(), "getVolume should return the updated volume.");
+        assertTrue(new File(SETTINGS_FILE).exists(), "settings.properties file should be created after setting volume.");
+    }
+
+    @Test
+    void testSetAndGetKey() {
+        settingsManager.setKey("UP", KeyEvent.VK_Z);
+        assertEquals(KeyEvent.VK_Z, settingsManager.getKey("UP"), "getKey should return the updated key for P1.");
+        assertTrue(new File(SETTINGS_FILE).exists(), "settings.properties file should be created after setting a key.");
+    }
+
+    @Test
+    void testSetAndGetKeyP2() {
+        settingsManager.setKeyP2("SHOOT", KeyEvent.VK_SHIFT);
+        assertEquals(KeyEvent.VK_SHIFT, settingsManager.getKeyP2("SHOOT"), "getKeyP2 should return the updated key for P2.");
+        assertTrue(new File(SETTINGS_FILE).exists(), "settings.properties file should be created after setting a P2 key.");
+    }
+
+    @Test
+    void testGetUnknownKey() {
+        assertEquals(-1, settingsManager.getKey("UNKNOWN_ACTION"), "getKey should return -1 for an unknown action.");
+        assertEquals(-1, settingsManager.getKeyP2("UNKNOWN_ACTION"), "getKeyP2 should return -1 for an unknown action.");
+    }
+
+    @Test
+    void testGetKeyBindings() {
+        assertNotNull(settingsManager.getKeyBindings(), "getKeyBindings should not return null.");
+        assertEquals(5, settingsManager.getKeyBindings().size(), "Default key bindings for P1 should have 5 actions.");
+    }
+
+    @Test
+    void testGetKeyBindingsP2() {
+        assertNotNull(settingsManager.getKeyBindingsP2(), "getKeyBindingsP2 should not return null.");
+        assertEquals(5, settingsManager.getKeyBindingsP2().size(), "Default key bindings for P2 should have 5 actions.");
+    }
+}

--- a/test/engine/InputManagerTest.java
+++ b/test/engine/InputManagerTest.java
@@ -5,97 +5,83 @@ import org.junit.jupiter.api.Test;
 import java.awt.event.KeyEvent;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class InputManagerTest {
 
     private InputManager inputManager;
+    private GameSettingsManager gameSettingsManager;
 
     @BeforeEach
     void setUp() {
-        // Since InputManager is a singleton, we get the instance.
-        // We need to reset its state before each test.
+        // We need to get the singleton instance for testing.
         inputManager = InputManager.getInstance();
-        // A way to reset the keys array is needed. Since there is no public reset method,
-        // we can use reflection, or just press and release a bunch of keys to get a known state.
-        // For simplicity, we'll rely on the fact that each test will set the keys it needs.
+        gameSettingsManager = GameSettingsManager.getInstance();
+
+        // Reset key states before each test.
+        for (int i = 0; i < 256; i++) {
+            if (inputManager.isKeyDown(i)) {
+                KeyEvent keyEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_RELEASED, 0, 0, i, (char) i);
+                inputManager.keyReleased(keyEvent);
+            }
+        }
+        inputManager.clearLastKeyCode();
     }
 
     @Test
     void testGetInstance() {
-        assertNotNull(inputManager);
-        assertSame(inputManager, InputManager.getInstance());
+        assertNotNull(inputManager, "getInstance should not return null.");
+        InputManager anotherInstance = InputManager.getInstance();
+        assertSame(inputManager, anotherInstance, "getInstance should return the same singleton instance.");
     }
 
     @Test
-    void testIsKeyDown_notPressed() {
-        // Ensure the key is not pressed before the test
-        KeyEvent keyEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, KeyEvent.VK_A, 'a');
-        inputManager.keyReleased(keyEvent);
-        assertFalse(inputManager.isKeyDown(KeyEvent.VK_A));
-    }
+    void testKeyPressedAndIsKeyDown() {
+        int keyCode = KeyEvent.VK_A;
+        assertFalse(inputManager.isKeyDown(keyCode), "Key should not be down initially.");
 
-    @Test
-    void testKeyPressedAndIsKeyDown_validKey() {
-        KeyEvent keyEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, KeyEvent.VK_B, 'b');
-        inputManager.keyPressed(keyEvent);
-        assertTrue(inputManager.isKeyDown(KeyEvent.VK_B));
-    }
-
-    @Test
-    void testKeyReleased_validKey() {
-        // First press the key
-        KeyEvent pressEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, KeyEvent.VK_C, 'c');
+        KeyEvent pressEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, 0, 0, keyCode, 'a');
         inputManager.keyPressed(pressEvent);
-        assertTrue(inputManager.isKeyDown(KeyEvent.VK_C));
 
-        // Then release it
-        KeyEvent releaseEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, KeyEvent.VK_C, 'c');
+        assertTrue(inputManager.isKeyDown(keyCode), "Key should be down after keyPressed event.");
+    }
+
+    @Test
+    void testKeyReleased() {
+        int keyCode = KeyEvent.VK_B;
+        KeyEvent pressEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, 0, 0, keyCode, 'b');
+        inputManager.keyPressed(pressEvent);
+        assertTrue(inputManager.isKeyDown(keyCode), "Key should be down after press.");
+
+        KeyEvent releaseEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_RELEASED, 0, 0, keyCode, 'b');
         inputManager.keyReleased(releaseEvent);
-        assertFalse(inputManager.isKeyDown(KeyEvent.VK_C));
+
+        assertFalse(inputManager.isKeyDown(keyCode), "Key should not be down after keyReleased event.");
     }
 
     @Test
-    void testKeyPressed_invalidKey_outOfBounds() {
-        // Test with a key code outside the valid range
-        KeyEvent keyEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, 300, ' ');
-        // The method should not throw an exception
-        assertDoesNotThrow(() -> inputManager.keyPressed(keyEvent));
+    void testLastKeyCode() {
+        assertEquals(-1, inputManager.getLastKeyCode(), "Last key code should be -1 initially.");
+
+        int firstKeyCode = KeyEvent.VK_C;
+        KeyEvent firstPress = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, 0, 0, firstKeyCode, 'c');
+        inputManager.keyPressed(firstPress);
+        assertEquals(firstKeyCode, inputManager.getLastKeyCode(), "Last key code should be updated after a key press.");
+
+        int secondKeyCode = KeyEvent.VK_D;
+        KeyEvent secondPress = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, 0, 0, secondKeyCode, 'd');
+        inputManager.keyPressed(secondPress);
+        assertEquals(secondKeyCode, inputManager.getLastKeyCode(), "Last key code should be updated to the most recent key press.");
     }
 
     @Test
-    void testKeyReleased_invalidKey_outOfBounds() {
-        // Test with a key code outside the valid range
-        KeyEvent keyEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, 300, ' ');
-        // The method should not throw an exception
-        assertDoesNotThrow(() -> inputManager.keyReleased(keyEvent));
-    }
-    
-    @Test
-    void testKeyTyped() {
-        KeyEvent keyEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_TYPED, System.currentTimeMillis(), 0, KeyEvent.VK_UNDEFINED, 'd');
-        // The method is empty, so we just call it for completeness and coverage.
-        assertDoesNotThrow(() -> inputManager.keyTyped(keyEvent));
-    }
-    
-    @Test
-    void testIsP1KeyDown() {
-        KeyEvent keyEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, KeyEvent.VK_P, 'p');
-        inputManager.keyPressed(keyEvent);
-        assertTrue(inputManager.isP1KeyDown(KeyEvent.VK_P));
-        
-        KeyEvent releaseEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, KeyEvent.VK_P, 'p');
-        inputManager.keyReleased(releaseEvent);
-        assertFalse(inputManager.isP1KeyDown(KeyEvent.VK_P));
-    }
+    void testClearLastKeyCode() {
+        int keyCode = KeyEvent.VK_E;
+        KeyEvent pressEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, 0, 0, keyCode, 'e');
+        inputManager.keyPressed(pressEvent);
+        assertNotEquals(-1, inputManager.getLastKeyCode(), "Last key code should be set.");
 
-    @Test
-    void testIsP2KeyDown() {
-        KeyEvent keyEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, KeyEvent.VK_Q, 'q');
-        inputManager.keyPressed(keyEvent);
-        assertTrue(inputManager.isP2KeyDown(KeyEvent.VK_Q));
-        
-        KeyEvent releaseEvent = new KeyEvent(mock(java.awt.Component.class), KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, KeyEvent.VK_Q, 'q');
-        inputManager.keyReleased(releaseEvent);
-        assertFalse(inputManager.isP2KeyDown(KeyEvent.VK_Q));
+        inputManager.clearLastKeyCode();
+        assertEquals(-1, inputManager.getLastKeyCode(), "Last key code should be -1 after clearing.");
     }
 }


### PR DESCRIPTION
This pull request introduces a comprehensive settings system to the game, allowing users to adjust audio volume and customize key bindings for both players. It implements a new `GameSettingsManager` singleton for persistent storage of settings, adds a modern settings menu screen, and refactors input and audio handling to be settings-aware. The changes also update the main menu and game loop to support the new settings screen.

The most important changes are:

**Settings System Implementation:**

* Introduced a new `GameSettingsManager` singleton class to manage game settings, including audio volume and key bindings for both players, with persistent storage in a `settings.properties` file. This manager loads settings at startup, provides getters/setters, and ensures changes are saved and applied immediately. [[1]](diffhunk://#diff-c2f05be045d7d7383d34d92221d273bfaaade805fc4e1928b266b88d637540b4R1-R128) [[2]](diffhunk://#diff-ca297c27fb4b195a1d7e4b5de51842826ba0c9571cb32fb027030cca28fdf8daR85-R87)

**Audio Volume Control:**

* Enhanced the `SoundManager` to support global volume control, including methods to set/get volume, update all loaded sounds, and integrate with the settings manager for persistence. Volume is now respected in all playback methods. [[1]](diffhunk://#diff-5ea4cad4e8f562425bd78d0b2b0beaa0d43ff117ec5b9a608e3b30b5db7445ccR13-R54) [[2]](diffhunk://#diff-5ea4cad4e8f562425bd78d0b2b0beaa0d43ff117ec5b9a608e3b30b5db7445ccR74) [[3]](diffhunk://#diff-5ea4cad4e8f562425bd78d0b2b0beaa0d43ff117ec5b9a608e3b30b5db7445ccL45-R93)

**Input Refactoring for Custom Key Bindings:**

* Refactored `InputManager` to support action-based input queries (e.g., `isActionPressed("UP")`) using the settings manager's key bindings, and removed player-specific hardcoded methods. Also added support for tracking the last key pressed for key rebinding. [[1]](diffhunk://#diff-f89f8056dc7b5e46932ebb7b2a5157ec8219933960aa2328e3a8dfd0e0404838R20-R28) [[2]](diffhunk://#diff-f89f8056dc7b5e46932ebb7b2a5157ec8219933960aa2328e3a8dfd0e0404838R53-R74) [[3]](diffhunk://#diff-f89f8056dc7b5e46932ebb7b2a5157ec8219933960aa2328e3a8dfd0e0404838R85) [[4]](diffhunk://#diff-f89f8056dc7b5e46932ebb7b2a5157ec8219933960aa2328e3a8dfd0e0404838L84-L91)

**Settings Menu Integration and UI:**

* Updated the main menu and `DrawManager` to add a "Settings" option and implemented a modern settings screen UI, including a volume slider, key binding panels for both players, and interactive overlays for rebinding keys. [[1]](diffhunk://#diff-b96b0829110698c492022c12fd539b0dd6925531631653b4869b260acdda52e5R4-R11) [[2]](diffhunk://#diff-b96b0829110698c492022c12fd539b0dd6925531631653b4869b260acdda52e5R21) [[3]](diffhunk://#diff-b96b0829110698c492022c12fd539b0dd6925531631653b4869b260acdda52e5R466) [[4]](diffhunk://#diff-b96b0829110698c492022c12fd539b0dd6925531631653b4869b260acdda52e5R486-R656) [[5]](diffhunk://#diff-ca297c27fb4b195a1d7e4b5de51842826ba0c9571cb32fb027030cca28fdf8daR269-L269)

**Gameplay and Screen Input Updates:**

* Modified game and screen logic (e.g., `GameScreen`, `CreditScreen`) to use the new action-based input methods, ensuring all input respects the current key bindings from the settings manager. [[1]](diffhunk://#diff-b1ca4b220a2001c7b0df0711630cfbfcb6967fff8907e04e1673eb3e322130a4L88-R88) [[2]](diffhunk://#diff-2cb83b1e334bad77df1b4983953635325b87a363c4518f6d3e9679e48be0b648L334-R338)

These changes collectively make the game's controls and audio more user-friendly and customizable, while laying groundwork for further extensibility.